### PR TITLE
FCProREST.js - GetOwnJobs -> GetAllJobs

### DIFF
--- a/lib/FCProREST.js
+++ b/lib/FCProREST.js
@@ -219,7 +219,7 @@ FCProREST.prototype.GetOwnJobs = function(status, cb) {
 [WebInvoke(RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json, Method = "GET", BodyStyle = WebMessageBodyStyle.Wrapped, UriTemplate = "/GetAllJobs?status={status}")]
 JobResult[] GetAllJobs(int status);
 */
-FCProREST.prototype.GetOwnJobs = function(status, cb) {
+FCProREST.prototype.GetAllJobs = function(status, cb) {
 	this._performRequest('/GetAllJobs', 'GET', {
 		status: status
 	}, cb);


### PR DESCRIPTION
For the requests to /GetOwnJobs and /GetAllJobs both function were named GetOwnJobs. Changed it to GetAllJobs for this request