### PR TITLE
FCProREST.js - single property results

### DIFF
--- a/lib/FCProREST.js
+++ b/lib/FCProREST.js
@@ -94,6 +94,8 @@ function FCProREST(host, port, endpoint, username, password, tempfolder){
 		      
 		      try {
 		    	  var responseObject = JSON.parse(responseString);
+		    	  var objKeys = Object.keys(responseObject);
+	                  if(objKeys.length == 1) { responseObject = responseObject[objKeys[0]]; }
 		    	  success(responseObject);
 		      }
 		      catch (err) {


### PR DESCRIPTION
if the response object has only one property, return this property instead